### PR TITLE
chore: resolve goconst linter issues in history manager

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -131,6 +131,50 @@ linters:
   # Linter Settings Configuration
   ######################################################################################################
   settings:
+    # https://golangci-lint.run/docs/linters/configuration/#goconst
+    goconst:
+      # Minimal length of string constant.
+      # Default: 3
+      min-len: 3
+      # Minimum occurrences of constant string count to trigger issue.
+      # Default: 3
+      min-occurrences: 5
+      # Look for existing constants matching the values.
+      # Default: true
+      match-constant: false
+      # Search also for duplicated numbers.
+      # Default: false
+      numbers: false
+      # Minimum value, only works with `goconst.numbers`.
+      # Default: 3
+      min: 3
+      # Maximum value, only works with `goconst.numbers`.
+      # Default: 3
+      max: 3
+      # Ignore when constant is not used as function argument.
+      # Default: true
+      ignore-calls: false
+      # Exclude strings matching the given regular expression.
+      # Default: ""
+      ignore-string-values:
+        - ""
+      # Detects constants with identical values.
+      # Default: false
+      find-duplicates: true
+      # Evaluates of constant expressions like Prefix + "suffix".
+      # Default: false
+      eval-const-expressions: false
+      # Ignore strings from test files.
+      # Default: false
+      ignore-tests: true
+      # Ignore string literals in calls to these functions
+      # Default: empty list
+      ignore-functions:
+        - "log.*"
+        - "slog.*"
+        - "fmt.Printf"
+        - "fmt.Errorf"
+        - "errors.New"
     gocritic:
       enable-all: true
       disabled-checks:

--- a/internal/history/manager.go
+++ b/internal/history/manager.go
@@ -43,6 +43,14 @@ var (
 	ErrNoHistory = errors.New("no deletion history found")
 )
 
+// Log field keys used across history operations.
+const (
+	logFieldBinary  = "binary"
+	logFieldEntryID = "entry_id"
+	logFieldPath    = "path"
+	logFieldTrash   = "trash"
+)
+
 // Manager defines high-level history operations.
 //
 // This interface provides the orchestration layer that coordinates trash,
@@ -197,7 +205,7 @@ func (m *HistoryManager) RecordDeletion(
 	}
 
 	m.logger.Debug().
-		Str("path", binaryPath).
+		Str(logFieldPath, binaryPath).
 		Msg("Recording binary deletion")
 
 	// Extract build info from binary
@@ -264,9 +272,9 @@ func (m *HistoryManager) RecordDeletion(
 	}
 
 	m.logger.Info().
-		Str("binary", record.BinaryName).
-		Str("path", binaryPath).
-		Str("trash", trashPath).
+		Str(logFieldBinary, record.BinaryName).
+		Str(logFieldPath, binaryPath).
+		Str(logFieldTrash, trashPath).
 		Msg("Binary deletion recorded")
 
 	return entryFromRecord(&record), nil
@@ -321,7 +329,7 @@ func (m *HistoryManager) UndoMostRecent(ctx context.Context) (*RestoreResult, er
 //   - An error if the operation fails
 func (m *HistoryManager) Restore(ctx context.Context, entryID string) (*RestoreResult, error) {
 	m.logger.Debug().
-		Str("entry_id", entryID).
+		Str(logFieldEntryID, entryID).
 		Msg("Restoring binary by entry ID")
 
 	// Get specific record
@@ -421,8 +429,8 @@ func (m *HistoryManager) restoreRecord(
 	}
 
 	m.logger.Info().
-		Str("binary", record.BinaryName).
-		Str("path", record.OriginalPath).
+		Str(logFieldBinary, record.BinaryName).
+		Str(logFieldPath, record.OriginalPath).
 		Msg("Binary restored from trash")
 
 	return &RestoreResult{
@@ -477,7 +485,7 @@ func (m *HistoryManager) GetHistory(ctx context.Context, limit int) ([]*HistoryE
 //   - An error if the operation fails
 func (m *HistoryManager) DeletePermanently(ctx context.Context, entryID string) error {
 	m.logger.Debug().
-		Str("entry_id", entryID).
+		Str(logFieldEntryID, entryID).
 		Msg("Permanently deleting binary")
 
 	// Get the record
@@ -505,8 +513,8 @@ func (m *HistoryManager) DeletePermanently(ctx context.Context, entryID string) 
 	}
 
 	m.logger.Info().
-		Str("binary", record.BinaryName).
-		Str("entry_id", entryID).
+		Str(logFieldBinary, record.BinaryName).
+		Str(logFieldEntryID, entryID).
 		Msg("Binary permanently deleted")
 
 	return nil
@@ -538,7 +546,7 @@ func (m *HistoryManager) ClearHistory(ctx context.Context, clearTrash bool) erro
 				if err := m.trasher.DeletePermanently(ctx, records[i].TrashPath); err != nil {
 					m.logger.Warn().
 						Err(err).
-						Str("binary", records[i].BinaryName).
+						Str(logFieldBinary, records[i].BinaryName).
 						Msg("Failed to delete binary from trash")
 				}
 			}
@@ -572,7 +580,7 @@ func (m *HistoryManager) ClearEntry(
 	deleteFromTrash bool,
 ) error {
 	m.logger.Debug().
-		Str("entry_id", entryID).
+		Str(logFieldEntryID, entryID).
 		Bool("delete_from_trash", deleteFromTrash).
 		Msg("Clearing history entry")
 
@@ -601,8 +609,8 @@ func (m *HistoryManager) ClearEntry(
 	}
 
 	m.logger.Info().
-		Str("binary", record.BinaryName).
-		Str("entry_id", entryID).
+		Str(logFieldBinary, record.BinaryName).
+		Str(logFieldEntryID, entryID).
 		Msg("History entry cleared")
 
 	return nil


### PR DESCRIPTION
This PR resolves outstanding goconst linter issues. 

A linter update resulted in an increased detection rate. Golangci-lint also introduced new configuration options to help maintain parity with the linter.

Updating the configuration and replacing a few hardcoded strings with constants resolves the issue.

## Changes

- Add goconst configuration to .golangci.yaml with custom settings
- Extract log field string constants in internal/history/manager.go
- Replace hardcoded log field strings with named constants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality configuration to enforce stricter standards.
  * Refactored internal logging to improve maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/go-remove/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->